### PR TITLE
Refactor icectl HTTP handling and synchronize locks cluster-wide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS
+
+Please run the following commands before submitting changes:
+
+- `go vet ./...`
+- `go test ./...`
+- `go test -race ./...`
+- `gosec ./...`
+

--- a/cmd/icecluster/consistency_test.go
+++ b/cmd/icecluster/consistency_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spetr/icecluster/internal/cluster"
+)
+
+func TestRunConsistencyDetectsMismatch(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "foo"), []byte("bar"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	peers := cluster.NewPeers("http://self")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/index" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`[{"Path":"foo","Size":4,"MTime":1}]`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	peers.Add(srv.URL)
+
+	if inc := runConsistency(peers, root, "", ""); inc == 0 {
+		t.Fatalf("expected inconsistency detected")
+	}
+}

--- a/internal/locking/locks_test.go
+++ b/internal/locking/locks_test.go
@@ -47,3 +47,16 @@ func TestReleaseByHolder(t *testing.T) {
 		t.Fatalf("/c should remain held")
 	}
 }
+
+func TestLoad(t *testing.T) {
+	m := NewManager()
+	_ = m.TryLock("/old", "n1")
+	list := []Info{{Path: "/new", Holder: "n2"}}
+	m.Load(list)
+	if _, ok := m.Holder("/old"); ok {
+		t.Fatalf("old lock should be cleared")
+	}
+	if h, ok := m.Holder("/new"); !ok || h != "n2" {
+		t.Fatalf("new lock missing or wrong holder: %v %v", h, ok)
+	}
+}


### PR DESCRIPTION
## Summary
- propagate lock/unlock operations to all peers for consistent state
- sync lock table from coordinator when nodes start or recover
- verify file state before syncing locks after peer recovery
- document gosec security scanning in AGENTS instructions

## Testing
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `gosec ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bca6795074832e86a4e463d82f549e